### PR TITLE
Put autogenerated id onto wrapped element

### DIFF
--- a/src/zingchart-angularjs.js
+++ b/src/zingchart-angularjs.js
@@ -19,6 +19,9 @@
                     id = 'zingchart-auto-' + currentAutoId;
                     currentAutoId++;
                     $attrs.id = id;
+                    // newly generated id has to be put back on the element too to meet
+                    // zingcharts requirements
+                    $element.attr('id', id);
                 }
                 else{
                     if($attrs.id.indexOf('{{') > -1){


### PR DESCRIPTION
For the autogenerated id scenario, zingcharts components were complaining about a lack of an id on the element itself. So insert the generated id onto the root element